### PR TITLE
Add `CITATION.cff` citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+cff-version: 1.2.0
+message: "If you use this book, please cite it as below."
+title: "Git in Practice"
+type: dataset
+authors:
+  - family-names: "McQuaid"
+    given-names: "Mike"
+    email: mike@mikemcquaid.com
+date-released: "2014-09-29"
+url: https://github.com/MikeMcQuaid/GitInPractice
+keywords:
+  - Software Engineering
+  - Development
+preffered-citation:
+  type: book
+  authors:
+    - family-names: "McQuaid"
+      given-names: "Mike"
+      email: mike@mikemcquaid.com
+  isbn: 9781617291975
+  title: "Git in Practice"
+  publisher: Manning
+  pages: 272
+  year: 2014
+  month: 9
+  url: https://github.com/MikeMcQuaid/GitInPractice


### PR DESCRIPTION
Hello @MikeMcQuaid,

I came across your book/repository and was missing a properly citation file. According to https://citation-file-format.github.io/, GitHub supports citation via the `CITATION.cff` file.
I created one and would like to contribute this upstream.

The [documentation](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#type) tells that the repository can only be declared as `software` or `dataset`. I would categorise it more as a "dataset" but it is not the best declaration since it is obviously a book. Therefore, I added the `preffered-citation` section where I specify more fitting metadata. 
If you want to see how the citation on GitHub looks like, feel free to check out my [working branch](https://github.com/maximiliantech/GitInPractice/tree/feat/repo-citation). On the right side you will see "Cite this repository".
The Bibtex file which gets generated has the following structure:

```bib
@misc{McQuaid_Git_in_Practice_2014,
author = {McQuaid, Mike},
month = sep,
title = {{Git in Practice}},
url = {https://github.com/MikeMcQuaid/GitInPractice},
year = {2014}
}
```

What do you think about it? I am happy to hear your feedback.